### PR TITLE
Add Bobs Crude Oil Processing

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -21,6 +21,9 @@ script.on_configuration_changed( function(data)
         recipes["advanced-oil-processing-GDIW-3"].enabled=true
         recipes["heavy-oil-cracking-GDIW"].enabled=true
         recipes["light-oil-cracking-GDIW"].enabled=true
+        if recipes["bob-oil-processing-GDIW"] then
+          recipes["bob-oil-processing-GDIW"].enabled=true
+        end
       end
       if techs["sulfur-processing"].researched then
         recipes["sulfur-GDIW"].enabled=true
@@ -51,6 +54,9 @@ script.on_configuration_changed( function(data)
         recipes["advanced-oil-processing-GDIW-3"].enabled=true
         recipes["heavy-oil-cracking-GDIW"].enabled=true
         recipes["light-oil-cracking-GDIW"].enabled=true
+        if recipes["bob-oil-processing-GDIW"] then
+          recipes["bob-oil-processing-GDIW"].enabled=true
+        end
       end
       if techs["sulfur-processing"].researched then
         recipes["sulfur-GDIW"].enabled=true

--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -4,5 +4,9 @@ for km, vm in pairs(data.raw.module) do
     for _, recipe in ipairs({"basic-oil-processing-GDIW-3","advanced-oil-processing-GDIW","advanced-oil-processing-GDIW-2","advanced-oil-processing-GDIW-3","heavy-oil-cracking-GDIW","light-oil-cracking-GDIW","sulfur-GDIW"}) do
       table.insert(vm.limitation, recipe)
     end
+
+    if data.raw["recipe"]["bob-oil-processing"] then
+      table.insert(vm.limitation, "bob-oil-processing-GDIW")
+    end
   end
 end

--- a/info.json
+++ b/info.json
@@ -6,5 +6,5 @@
   "homepage": "",
   "contact": "dacyclops@dacyclops.com",
   "description": "Gah!DarnItWater! A Factorio mod for those people who keep getting annoyed at water....",
-  "dependencies": ["base >= 0.12.11"]
+  "dependencies": ["base >= 0.12.11", "? bobplates >= 0.12.0"]
 }

--- a/locale/en/en.cfg
+++ b/locale/en/en.cfg
@@ -1,5 +1,6 @@
 [recipe-name]
 basic-oil-processing-GDIW-3=Basic oil processing (NR)
+bob-oil-processing-GDIW=Crude Oil Processing (NR)
 advanced-oil-processing-GDIW=Advanced oil processing (RN)
 advanced-oil-processing-GDIW-2=Advanced oil processing (RR)
 advanced-oil-processing-GDIW-3=Advanced oil processing (NR)

--- a/prototypes/GDIW.lua
+++ b/prototypes/GDIW.lua
@@ -170,3 +170,31 @@ table.insert(data.raw["technology"]["advanced-oil-processing"].effects,{type="un
 table.insert(data.raw["technology"]["advanced-oil-processing"].effects,{type="unlock-recipe",recipe="light-oil-cracking-GDIW"})
 table.insert(data.raw["technology"]["sulfur-processing"].effects,{type="unlock-recipe",recipe="sulfur-GDIW"})
 table.insert(data.raw["technology"]["flame-thrower"].effects,{type="unlock-recipe",recipe="flame-thrower-ammo-GDIW"})
+
+
+if data.raw["recipe"]["bob-oil-processing"] then
+data:extend({
+  {
+    type = "recipe",
+    name = "bob-oil-processing-GDIW",
+    category = "oil-processing",
+    enabled = false,
+    energy_required = 5,
+    ingredients =
+    {
+      {type="fluid", name="crude-oil", amount=10}
+    },
+    results=
+    {
+      {type="fluid", name="petroleum-gas", amount=3},
+      {type="fluid", name="light-oil", amount=2},
+      {type="fluid", name="heavy-oil", amount=5}
+    },
+    icon = "__GDIW__/graphics/basic-oil-processing-GDIW-3.png",
+    subgroup = "fluid-recipes",
+    order = "a[oil-processing]-c[bob-oil-processing-2]"
+  },
+})
+
+table.insert(data.raw["technology"]["advanced-oil-processing"].effects,{type="unlock-recipe",recipe="bob-oil-processing-GDIW"})
+end


### PR DESCRIPTION
This should allow anyone who has Bobs Plates installed to have a reversed version of its Crude Oil Processing. The optional dependency in the info.json and the conditional checks everywhere should mean that this wont effect users who do not use Bobs mods.

I have tested this with an in progress Bobs mod game, and a new start bobs mod game. Please verify everything works fine in a vanilla game (a little lazyness on my part)
