### PR TITLE
Bump to version 1.1 of factorio

### DIFF
--- a/info.json
+++ b/info.json
@@ -1,12 +1,12 @@
 {
   "name": "GDIW",
-  "version": "0.18.0",
+  "version": "1.1",
   "title": "GDIW - Gah! DarnItWater!",
   "author": "DaCyclops",
   "homepage": "",
   "contact": "dacyclops@dacyclops.com",
   "description": "Allows switching liquid recipe inputs and outputs.",
-  "factorio_version":"0.18",
+  "factorio_version":"1.1",
   "dependencies": [
     "(?) angelspetrochem ",
     "(?) angelssmelting ",


### PR DESCRIPTION
Apparently it's very easy to update the mod, just change the info.json parameters. 
Haven't done extensive testing, but see no reason why it shouldn't work.